### PR TITLE
Fix empty struct meta check

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -223,15 +223,21 @@ func (e *encoder) structv(tag string, in reflect.Value, comment comments) {
 
 	// ensure valid non nil struct meta before using
 	if fIndex := getYamlMeta(in, fieldsIndex); (fIndex.IsValid() && fIndex.Elem() != reflect.Value{}) {
-		if meta, ok := fIndex.Elem().Interface().(StructMeta); ok {
-			fieldsIndex = meta.GetFieldsIndex()
-			commentsArr = meta.GetComments()
+		meta, ok := fIndex.Elem().Interface().(StructMeta)
+		metaFieldsIndex := meta.GetFieldsIndex()
+		metaCommentsArr := meta.GetComments()
+		if ok && len(metaFieldsIndex) == len(metaCommentsArr) {
+			fieldsIndex = metaFieldsIndex
+			commentsArr = metaCommentsArr
 		}
 	}
 
 	e.mappingv(tag, comment, func() {
 		processed := map[int]bool{}
 		for i, info := range fieldsIndex {
+			if info.Key == yamlMeta {
+				continue
+			}
 			var value reflect.Value
 			if info.Inline == nil {
 				value = in.Field(info.Num)

--- a/encode.go
+++ b/encode.go
@@ -223,9 +223,10 @@ func (e *encoder) structv(tag string, in reflect.Value, comment comments) {
 
 	// ensure valid non nil struct meta before using
 	if fIndex := getYamlMeta(in, fieldsIndex); (fIndex.IsValid() && fIndex.Elem() != reflect.Value{}) {
-		meta := fIndex.Elem().Interface().(StructMeta)
-		fieldsIndex = meta.GetFieldsIndex()
-		commentsArr = meta.GetComments()
+		if meta, ok := fIndex.Elem().Interface().(StructMeta); ok {
+			fieldsIndex = meta.GetFieldsIndex()
+			commentsArr = meta.GetComments()
+		}
 	}
 
 	e.mappingv(tag, comment, func() {

--- a/encode.go
+++ b/encode.go
@@ -221,7 +221,8 @@ func (e *encoder) structv(tag string, in reflect.Value, comment comments) {
 
 	commentsArr := makeEmptyComments(len(fieldsIndex))
 
-	if fIndex := getYamlMeta(in, fieldsIndex); fIndex.IsValid() {
+	// ensure valid non nil struct meta before using
+	if fIndex := getYamlMeta(in, fieldsIndex); (fIndex.IsValid() && fIndex.Elem() != reflect.Value{}) {
 		meta := fIndex.Elem().Interface().(StructMeta)
 		fieldsIndex = meta.GetFieldsIndex()
 		commentsArr = meta.GetComments()

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/structmeta_internal_test.go
+++ b/structmeta_internal_test.go
@@ -30,6 +30,50 @@ var structMetaTests = []string{
 	"a: ant #ant\n# a\nb: #beeline\n    c: cockroach #cockroach\n    #c\n    #d\n    d: dragonfly\n    #dragonfly\n",
 }
 
+var structMetaNilTests = []struct {
+	expected string
+	test     testStruct
+}{
+	{
+		"b:\n    d: d\n    c: c\na: a\n",
+		testStruct{
+			A: "a",
+			B: smChildStruct{
+				C: "c",
+				D: "d",
+			},
+		},
+	},
+	{
+		"b:\n    d: d\n    c: c\na: a\n",
+		testStruct{
+			A: "a",
+			B: smChildStruct{
+				C: "c",
+				D: "d",
+			},
+			Meta: StructMeta(&structMeta{nil, nil}),
+		},
+	},
+	{
+		"b:\n    d: d\n    c: c\na: a\n",
+		testStruct{
+			A: "a",
+			B: smChildStruct{
+				C: "c",
+				D: "d",
+			},
+			Meta: StructMeta(&structMeta{
+				[]fieldInfo{{
+					Key: "a",
+					Num: 2,
+				}},
+				[][]comments{},
+			}),
+		},
+	},
+}
+
 func (s *S) TestStructMeta(c *C) {
 	for _, expected := range structMetaTests {
 		c.Logf("test %s.", expected)
@@ -41,5 +85,19 @@ func (s *S) TestStructMeta(c *C) {
 		actual, err := Marshal(test)
 		c.Assert(err, Equals, nil)
 		c.Assert(string(actual), Equals, expected)
+	}
+}
+
+func (s *S) TestStructMetaNil(c *C) {
+	for _, in := range structMetaNilTests {
+		c.Logf("test %s", in.expected)
+
+		// test := &testStruct{}
+		// err := Unmarshal([]byte(expected), test)
+		// c.Assert(err, Equals, nil)
+
+		actual, err := Marshal(in.test)
+		c.Assert(err, Equals, nil)
+		c.Assert(string(actual), Equals, in.expected)
 	}
 }

--- a/structmeta_internal_test.go
+++ b/structmeta_internal_test.go
@@ -92,10 +92,6 @@ func (s *S) TestStructMetaNil(c *C) {
 	for _, in := range structMetaNilTests {
 		c.Logf("test %s", in.expected)
 
-		// test := &testStruct{}
-		// err := Unmarshal([]byte(expected), test)
-		// c.Assert(err, Equals, nil)
-
 		actual, err := Marshal(in.test)
 		c.Assert(err, Equals, nil)
 		c.Assert(string(actual), Equals, in.expected)


### PR DESCRIPTION
We weren't checking for empty through all interfaces, causes a panic if struct meta field exists but is nil. 

Notable this means `wectl state fetch` works but `wectl init` does not work if you have upgraded to latest CLI with `wectl uppgrade`, as it doesn't populate its yaml meta fields leading to a panic.

Added test cases for the 3 possible bad states, nil interface, nil arrays and index oob for comments array